### PR TITLE
Bug correct - FN (FP) related to pos (neg) misclassification rate

### DIFF
--- a/MakingNoiseApp.R
+++ b/MakingNoiseApp.R
@@ -148,8 +148,8 @@ server <- function(input, output,session) {
       p <- input$p
       sens <- input$sens
       spec <- input$spec
-      pos.mc.wt <- input$FP
-      neg.mc.wt <- input$FN
+      pos.mc.wt <- input$FN
+      neg.mc.wt <- input$FP
       reps <- 100
       
       # Create Simulated Data Set
@@ -210,8 +210,8 @@ server <- function(input, output,session) {
     axis(1,at=c(0,5,10,15,20,25,30,35,40,45,50),labels=round(mc.wts.rates$neg.misclass.rate*100,digits=1),line=3,cex.axis=1.5)
     axis(2,at=seq(from=0.0,to=1,by=0.1),cex.axis=1.5,las=2)
     mtext('Comparator Misclassification rate (%)',side=1,line=6,cex=1.5)
-    mtext('FP rate:',1,line=0.5,at=-3.5,cex=1.5)
-    mtext('FN rate:',1,line=3.5,at=-3.5,cex=1.5)
+    mtext('FN rate:',1,line=0.5,at=-3.5,cex=1.5)
+    mtext('FP rate:',1,line=3.5,at=-3.5,cex=1.5)
     for (lvl in seq(from=0.0,to=1,by=0.1)) {abline(h=lvl,lty=2,xpd=F)} # horiz grid lines
     pcs = c(0,5,10,15,20,25,30,35,40,45,50)
     metrics =  c("AUC","Sensitivity","Specificity","Pos Pred Value","Neg Pred Value") #


### PR DESCRIPTION
The positive misclassification rate as used in the code of the shiny app and as explained in your paper is related to the misclassified samples among those with **positive** ground truth. Those are the false-**negative** samples. Same for negative MC rate which should be related to FP. Therefore, at the 2 positions in the code FN and FP should be flipped to obtain correct results.  

Otherwise great app and very relevant paper!

_Note; One thing that confused me at first is also related to that nomenclature: Isn't the positive MC rate of the comparator just one (1) minus its sensitivity vs. ground truth? And the negative MC rate is just 1 - Specificity. Why use different terms for the method compared under investigation (Sense/Spec) vs. the comparator method (pos/neg MC rate)? Also, with that understanding, it is very straightforward to compute the FN to FP ratio: For example, if the comparator has a sensitivity of 93% and a specificity of 88%, this corresponds to a FN/FP-ratio of (100-93)/(100-88) = 7/12.